### PR TITLE
feat: add maintenance copilot docker stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# Sado-Cording
-upbit auto coin trading
+# Sado Maintenance Copilot Stack
+
+Synology Container Manager에서 24시간 운영 가능한 설비 보전/투자 코파일럿 참고 구성입니다.
+
+## 구성 요소
+- **API (FastAPI, :8000)**: 포트폴리오 제안, 설비 인사이트, 벡터스토어 연동.
+- **Dashboard (FastAPI, :8080)**: 정적 대시보드 + API 프락시.
+- **Scheduler (Python schedule)**: 주기적 데이터 인덱싱/캐시.
+- **Vectorstore (선택, :9000)**: FAISS 기반 간단한 임베딩 검색. `docker compose --profile faiss` 로 활성화.
+
+## 빠른 시작
+```bash
+# LF 유지, 실행권한 보존을 위해 Git 설정 권장
+git config core.autocrlf false
+
+# Synology Container Manager 또는 표준 Docker
+docker compose up --build -d
+
+# 벡터스토어까지 기동하려면
+docker compose --profile faiss up --build -d
+```
+
+## 데이터 경로
+- `./data` 디렉터리가 모든 컨테이너에 마운트됩니다.
+- 권한 이슈 발생 시 Synology File Station에서 1000:1000 권한 부여 또는 `PUID/PGID` 환경변수를 추가하세요.
+- 포트 충돌 시 `docker-compose.yml`의 `ports` 매핑을 수정해 호스트 포트만 바꿔주면 됩니다.
+
+## 헬스체크
+모든 서비스는 `python -c` 기반 헬스체크를 사용하므로 BusyBox 환경에서도 동작합니다.
+
+## 개발 가이드
+```bash
+# API 로컬 실행
+cd api && uvicorn src.main:app --reload --port 8000
+
+# Scheduler 단발성 실행 (데이터 캐시 생성)
+cd scheduler && python -m src.main --dry-run
+
+# Dashboard 확인
+cd dashboard && uvicorn src.app:app --reload --port 8080
+```
+
+## 테스트 데이터
+`data/*.csv`에 샘플 ETF, 코인, 설비 로그가 포함되어 있으니 필요 시 교체하세요.

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src /app/src
+COPY ../data /app/data
+EXPOSE 8000
+CMD ["uvicorn", "src.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,0 +1,8 @@
+fastapi==0.110.1
+uvicorn[standard]==0.29.0
+pydantic-settings==2.2.1
+httpx==0.27.0
+pandas==2.2.2
+numpy==1.26.4
+scikit-learn==1.4.2
+faiss-cpu==1.8.0

--- a/api/src/__init__.py
+++ b/api/src/__init__.py
@@ -1,0 +1,1 @@
+"""Maintenance copilot API package."""

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -1,0 +1,15 @@
+from functools import lru_cache
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    data_root: str = "/app/data"
+    vector_host: str = "vectorstore"
+    vector_port: int = 9000
+
+    model_config = SettingsConfigDict(env_prefix="", case_sensitive=False)
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/api/src/main.py
+++ b/api/src/main.py
@@ -1,0 +1,117 @@
+"""FastAPI service exposing maintenance copilot endpoints.
+
+Run: uvicorn src.main:app --host 0.0.0.0 --port 8000
+Test: python -m httpx get http://127.0.0.1:8000/healthz
+Deploy: docker compose up --build api
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+from typing import Dict, List
+
+import pandas as pd
+from fastapi import FastAPI, HTTPException
+
+from .config import get_settings
+from .vector import VectorClient
+
+app = FastAPI(title="Sado Maintenance Copilot API", version="0.1.0")
+
+settings = get_settings()
+vector_client = VectorClient(settings.vector_host, settings.vector_port)
+
+
+def _resolve(path: str | Path) -> Path:
+    return Path(path).expanduser().resolve()
+
+
+def load_dataframe(name: str) -> pd.DataFrame:
+    data_path = _resolve(settings.data_root) / f"{name}.csv"
+    if not data_path.exists():
+        return pd.DataFrame()
+    return pd.read_csv(data_path)
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, str]:
+    return {
+        "status": "ok",
+        "timestamp": datetime.utcnow().isoformat(),
+    }
+
+
+@app.get("/portfolio/suggestion")
+def portfolio_suggestion(risk_level: str = "balanced") -> Dict[str, List[Dict[str, float]]]:
+    risk_level = risk_level.lower()
+    if risk_level not in {"conservative", "balanced", "aggressive"}:
+        raise HTTPException(status_code=400, detail="risk_level must be conservative|balanced|aggressive")
+
+    etf_df = load_dataframe("etf_signals")
+    coin_df = load_dataframe("coin_signals")
+
+    allocations: Dict[str, List[Dict[str, float]]] = {"etf": [], "coin": []}
+
+    if not etf_df.empty:
+        allocations["etf"] = _build_allocations(etf_df, risk_level)
+    if not coin_df.empty:
+        allocations["coin"] = _build_allocations(coin_df, risk_level)
+
+    return allocations
+
+
+@app.get("/maintenance/insights")
+def maintenance_insights(equipment_id: str | None = None) -> Dict[str, List[Dict[str, str]]]:
+    df = load_dataframe("maintenance_logs")
+    if df.empty:
+        return {"insights": []}
+
+    if equipment_id:
+        df = df[df["equipment_id"] == equipment_id]
+
+    df = df.sort_values("timestamp", ascending=False).head(50)
+    insights = [
+        {
+            "equipment_id": row.equipment_id,
+            "issue": row.issue,
+            "recommendation": row.recommendation,
+            "timestamp": row.timestamp,
+        }
+        for row in df.itertuples()
+    ]
+    return {"insights": insights}
+
+
+@app.post("/vector/upsert")
+def vector_upsert(items: List[Dict[str, str]]):
+    if not items:
+        raise HTTPException(status_code=400, detail="no items provided")
+    result = vector_client.upsert(items)
+    return {"upserted": result}
+
+
+@app.post("/vector/query")
+def vector_query(query: Dict[str, str]):
+    if "text" not in query:
+        raise HTTPException(status_code=400, detail="text field required")
+    return {"matches": vector_client.query(query["text"], top_k=int(query.get("top_k", 5)))}
+
+
+def _build_allocations(df: pd.DataFrame, risk_level: str) -> List[Dict[str, float]]:
+    weight_column = {
+        "conservative": "weight_low",
+        "balanced": "weight_mid",
+        "aggressive": "weight_high",
+    }[risk_level]
+    if weight_column not in df.columns:
+        raise HTTPException(status_code=500, detail=f"missing column {weight_column}")
+
+    allocations = [
+        {
+            "symbol": row.symbol,
+            "weight": float(row[weight_column]),
+            "score": float(row.signal_score) if "signal_score" in df.columns else 0.0,
+        }
+        for _, row in df.iterrows()
+    ]
+    return allocations

--- a/api/src/vector.py
+++ b/api/src/vector.py
@@ -1,0 +1,40 @@
+"""Utility for interacting with optional FAISS vector store service.
+
+Run: python -m src.vector
+Test: python -m unittest discover -s src -p 'test_*.py'
+Deploy: docker compose --profile faiss up --build vectorstore
+"""
+from __future__ import annotations
+
+import json
+from typing import Dict, List
+
+import httpx
+
+
+class VectorClient:
+    def __init__(self, host: str, port: int) -> None:
+        self.base_url = f"http://{host}:{port}"
+
+    def upsert(self, items: List[Dict[str, str]]) -> int:
+        try:
+            response = httpx.post(f"{self.base_url}/upsert", json={"items": items}, timeout=10)
+            response.raise_for_status()
+            data = response.json()
+            return int(data.get("upserted", 0))
+        except httpx.HTTPError:
+            return 0
+
+    def query(self, text: str, top_k: int = 5) -> List[Dict[str, str]]:
+        try:
+            response = httpx.post(f"{self.base_url}/query", json={"text": text, "top_k": top_k}, timeout=10)
+            response.raise_for_status()
+            return response.json().get("matches", [])
+        except httpx.HTTPError:
+            return []
+
+
+if __name__ == "__main__":
+    client = VectorClient("127.0.0.1", 9000)
+    sample = [{"id": "demo", "text": "Synology predictive maintenance"}]
+    print(json.dumps({"upserted": client.upsert(sample)}, indent=2))

--- a/dashboard/Dockerfile
+++ b/dashboard/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src /app/src
+COPY src/index.html /app/static/index.html
+EXPOSE 8080
+CMD ["uvicorn", "src.app:app", "--host", "0.0.0.0", "--port", "8080"]

--- a/dashboard/requirements.txt
+++ b/dashboard/requirements.txt
@@ -1,0 +1,4 @@
+fastapi==0.110.1
+uvicorn[standard]==0.29.0
+jinja2==3.1.3
+httpx==0.27.0

--- a/dashboard/src/app.py
+++ b/dashboard/src/app.py
@@ -1,0 +1,45 @@
+"""Dashboard FastAPI serving a static maintenance cockpit.
+
+Run: uvicorn src.app:app --host 0.0.0.0 --port 8080
+Test: python -m httpx get http://127.0.0.1:8080/healthz
+Deploy: docker compose up --build dashboard
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict
+
+import httpx
+from fastapi import FastAPI, HTTPException
+from fastapi.responses import HTMLResponse
+from fastapi.staticfiles import StaticFiles
+
+API_BASE = "http://api:8000"
+
+app = FastAPI(title="Sado Maintenance Dashboard", version="0.1.0")
+app.mount("/static", StaticFiles(directory=Path(__file__).parent), name="static")
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.get("/")
+async def index() -> HTMLResponse:
+    index_path = Path(__file__).parent / "index.html"
+    html = index_path.read_text(encoding="utf-8")
+    async with httpx.AsyncClient(timeout=20.0) as client:
+        try:
+            portfolio = await _fetch(client, "/portfolio/suggestion?risk_level=balanced")
+            maintenance = await _fetch(client, "/maintenance/insights")
+        except httpx.HTTPError as exc:
+            raise HTTPException(status_code=502, detail=str(exc)) from exc
+    html = html.replace("{{PORTFOLIO_JSON}}", portfolio).replace("{{MAINTENANCE_JSON}}", maintenance)
+    return HTMLResponse(content=html)
+
+
+async def _fetch(client: httpx.AsyncClient, endpoint: str) -> str:
+    response = await client.get(f"{API_BASE}{endpoint}")
+    response.raise_for_status()
+    return response.text

--- a/dashboard/src/index.html
+++ b/dashboard/src/index.html
@@ -1,0 +1,80 @@
+<!DOCTYPE html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Sado Maintenance Copilot</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <style>
+      body { font-family: "Segoe UI", sans-serif; margin: 0; background: #0f172a; color: #e2e8f0; }
+      header { padding: 1.5rem; background: #1e293b; }
+      main { padding: 1.5rem; display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(320px, 1fr)); }
+      section { background: #1e293b; border-radius: 12px; padding: 1.5rem; box-shadow: 0 4px 20px rgba(15, 23, 42, 0.4); }
+      h1, h2 { margin: 0 0 1rem 0; }
+      table { width: 100%; border-collapse: collapse; }
+      th, td { padding: 0.5rem; border-bottom: 1px solid #334155; text-align: left; }
+      .badge { border-radius: 9999px; padding: 0.2rem 0.6rem; font-size: 0.8rem; background: #38bdf8; color: #0f172a; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>설비 보전 Copilot 현황판</h1>
+      <p>미국 ETF &amp; 코인 포트폴리오와 공장 설비 진단을 한눈에 확인하세요.</p>
+    </header>
+    <main>
+      <section>
+        <h2>포트폴리오 제안 (Balanced)</h2>
+        <div id="portfolio"></div>
+      </section>
+      <section>
+        <h2>최근 설비 인사이트</h2>
+        <div id="maintenance"></div>
+      </section>
+    </main>
+    <script>
+      const portfolioData = JSON.parse('{{PORTFOLIO_JSON}}');
+      const maintenanceData = JSON.parse('{{MAINTENANCE_JSON}}');
+
+      function renderPortfolio() {
+        const wrap = document.getElementById('portfolio');
+        const entries = [...(portfolioData.etf || []), ...(portfolioData.coin || [])];
+        if (!entries.length) {
+          wrap.innerHTML = '<p>데이터가 아직 없습니다. 스케줄러가 곧 채워줍니다.</p>';
+          return;
+        }
+        wrap.innerHTML = `
+          <table>
+            <thead>
+              <tr><th>자산</th><th>비중</th><th>신호</th></tr>
+            </thead>
+            <tbody>
+              ${entries.map(item => `
+                <tr>
+                  <td><span class="badge">${item.symbol}</span></td>
+                  <td>${(item.weight * 100).toFixed(1)}%</td>
+                  <td>${(item.score || 0).toFixed(2)}</td>
+                </tr>`).join('')}
+            </tbody>
+          </table>`;
+      }
+
+      function renderMaintenance() {
+        const wrap = document.getElementById('maintenance');
+        const entries = maintenanceData.insights || [];
+        if (!entries.length) {
+          wrap.innerHTML = '<p>등록된 고장 이력이 없습니다.</p>';
+          return;
+        }
+        wrap.innerHTML = entries.slice(0, 10).map(item => `
+          <article style="margin-bottom:1rem;">
+            <h3>${item.equipment_id}</h3>
+            <p><strong>Issue:</strong> ${item.issue}</p>
+            <p><strong>Recommendation:</strong> ${item.recommendation}</p>
+            <p style="font-size:0.85rem;color:#94a3b8;">${item.timestamp}</p>
+          </article>`).join('');
+      }
+
+      renderPortfolio();
+      renderMaintenance();
+    </script>
+  </body>
+</html>

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,7 @@
+# Data Directory
+
+- `raw/`: 원본 센서/시장 데이터 적재 위치
+- `logs/`: 서비스 로그 및 스케줄러 상태 파일 저장
+- `models/`: 학습된 모델 또는 벡터 인덱스 백업
+
+스케줄러가 CSV 캐시를 생성하면 `etf_signals.csv`, `coin_signals.csv`, `maintenance_logs.csv` 등의 파일이 자동으로 채워집니다.

--- a/data/coin_signals.csv
+++ b/data/coin_signals.csv
@@ -1,0 +1,4 @@
+symbol,signal_score,weight_low,weight_mid,weight_high
+BTC,0.7,0.4,0.45,0.5
+ETH,0.75,0.4,0.4,0.35
+SOL,0.5,0.2,0.15,0.15

--- a/data/etf_signals.csv
+++ b/data/etf_signals.csv
@@ -1,0 +1,4 @@
+symbol,signal_score,weight_low,weight_mid,weight_high
+VOO,0.8,0.5,0.4,0.2
+VXUS,0.6,0.3,0.3,0.25
+ARKK,0.4,0.2,0.3,0.55

--- a/data/maintenance_logs.csv
+++ b/data/maintenance_logs.csv
@@ -1,0 +1,4 @@
+equipment_id,issue,recommendation,timestamp
+PRESS-3,Bearing temperature spike,Schedule lubrication and vibration analysis,2024-05-01T09:30:00Z
+CNC-7,Spindle vibration rising,Inspect spindle bearings and balance tooling,2024-05-01T07:15:00Z
+KILN-2,Motor current anomaly,Check inverter settings and replace worn contactors,2024-04-30T23:45:00Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,80 @@
+version: "3.9"
+services:
+  api:
+    build: ./api
+    container_name: sado_api
+    restart: unless-stopped
+    ports:
+      - "8000:8000"
+    environment:
+      - DATA_ROOT=/app/data
+      - VECTOR_HOST=vectorstore
+      - VECTOR_PORT=9000
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      vectorstore:
+        condition: service_started
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8000/healthz', timeout=5).status==200 else 1)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  dashboard:
+    build: ./dashboard
+    container_name: sado_dashboard
+    restart: unless-stopped
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./data:/app/data:ro
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request,sys;sys.exit(0 if urllib.request.urlopen('http://127.0.0.1:8080/healthz', timeout=5).status==200 else 1)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+  scheduler:
+    build: ./scheduler
+    container_name: sado_scheduler
+    restart: unless-stopped
+    environment:
+      - API_BASE=http://api:8000
+      - DATA_ROOT=/app/data
+      - INDEX_INTERVAL_MINUTES=60
+    volumes:
+      - ./data:/app/data
+    depends_on:
+      api:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import os,sys,time;sys.exit(0 if os.path.exists('/tmp/scheduler_heartbeat') and time.time()-os.path.getmtime('/tmp/scheduler_heartbeat')<120 else 1)"]
+      interval: 60s
+      timeout: 10s
+      retries: 2
+      start_period: 30s
+
+  vectorstore:
+    build:
+      context: ./vectorstore
+    container_name: sado_vectorstore
+    restart: unless-stopped
+    ports:
+      - "9000:9000"
+    volumes:
+      - ./data:/app/data
+    profiles: ["faiss"]
+    healthcheck:
+      test: ["CMD", "python", "-c", "import socket,sys; s=socket.create_connection(('127.0.0.1',9000),5); s.close(); sys.exit(0)"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 20s
+
+volumes: {}

--- a/scheduler/Dockerfile
+++ b/scheduler/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src /app/src
+VOLUME ["/app/data"]
+CMD ["python", "-m", "src.main"]

--- a/scheduler/requirements.txt
+++ b/scheduler/requirements.txt
@@ -1,0 +1,4 @@
+httpx==0.27.0
+pydantic-settings==2.2.1
+schedule==1.2.1
+pandas==2.2.2

--- a/scheduler/src/main.py
+++ b/scheduler/src/main.py
@@ -1,0 +1,109 @@
+"""Scheduler service for recurring data ingestion and indexing.
+
+Run: python -m src.main
+Test: python -m src.main --dry-run
+Deploy: docker compose up --build scheduler
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import httpx
+import pandas as pd
+import schedule
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    api_base: str = "http://api:8000"
+    data_root: str = "/app/data"
+    index_interval_minutes: int = 60
+
+    model_config = SettingsConfigDict(env_prefix="", case_sensitive=False)
+
+
+settings = Settings()
+heartbeat_path = Path("/tmp/scheduler_heartbeat")
+
+
+def fetch_signals(endpoint: str) -> Dict[str, Any]:
+    with httpx.Client(timeout=30.0) as client:
+        response = client.get(f"{settings.api_base}{endpoint}")
+        response.raise_for_status()
+        return response.json()
+
+
+def persist_dataframe(name: str, payload: Any) -> None:
+    rows: Iterable[Dict[str, Any]]
+    if isinstance(payload, dict):
+        rows_list: list[Dict[str, Any]] = []
+        for bucket, items in payload.items():
+            if not isinstance(items, list):
+                continue
+            for item in items:
+                if isinstance(item, dict):
+                    rows_list.append({"bucket": bucket, **item})
+        rows = rows_list
+    elif isinstance(payload, list):
+        rows = [item for item in payload if isinstance(item, dict)]
+    else:
+        return
+
+    df = pd.DataFrame(list(rows))
+    if df.empty:
+        return
+    path = Path(settings.data_root) / f"{name}.csv"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    df.to_csv(path, index=False)
+
+
+def update_portfolio_cache() -> None:
+    for risk in ("conservative", "balanced", "aggressive"):
+        portfolio = fetch_signals(f"/portfolio/suggestion?risk_level={risk}")
+        persist_dataframe(f"portfolio_{risk}", portfolio)
+    _touch_heartbeat()
+
+
+def update_maintenance_logs() -> None:
+    logs = fetch_signals("/maintenance/insights")
+    persist_dataframe("maintenance_snapshot", logs.get("insights", []))
+    _touch_heartbeat()
+
+
+def run_index_cycle() -> None:
+    update_portfolio_cache()
+    update_maintenance_logs()
+
+
+def _touch_heartbeat() -> None:
+    heartbeat_path.write_text(datetime.utcnow().isoformat())
+
+
+def main(dry_run: bool = False) -> None:
+    if dry_run:
+        run_index_cycle()
+        return
+
+    schedule.every(settings.index_interval_minutes).minutes.do(run_index_cycle)
+    run_index_cycle()
+
+    while True:
+        schedule.run_pending()
+        time.sleep(5)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dry-run", action="store_true", help="execute one cycle and exit")
+    args = parser.parse_args()
+    try:
+        main(dry_run=args.dry_run)
+    except httpx.HTTPError as exc:
+        print(json.dumps({"error": str(exc)}))
+        os._exit(1)

--- a/vectorstore/Dockerfile
+++ b/vectorstore/Dockerfile
@@ -1,0 +1,9 @@
+FROM python:3.11-slim
+WORKDIR /app
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
+COPY requirements.txt /app/requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+COPY src /app/src
+EXPOSE 9000
+CMD ["uvicorn", "src.server:app", "--host", "0.0.0.0", "--port", "9000"]

--- a/vectorstore/requirements.txt
+++ b/vectorstore/requirements.txt
@@ -1,0 +1,5 @@
+fastapi==0.110.1
+uvicorn[standard]==0.29.0
+faiss-cpu==1.8.0
+numpy==1.26.4
+pydantic==1.10.14

--- a/vectorstore/src/__init__.py
+++ b/vectorstore/src/__init__.py
@@ -1,0 +1,1 @@
+"""Vector store package."""

--- a/vectorstore/src/server.py
+++ b/vectorstore/src/server.py
@@ -1,0 +1,102 @@
+"""Minimal FAISS-backed vector microservice.
+
+Run: uvicorn src.server:app --host 0.0.0.0 --port 9000
+Test: python -m httpx post http://127.0.0.1:9000/upsert -j '{"items":[]}'
+Deploy: docker compose --profile faiss up --build vectorstore
+"""
+from __future__ import annotations
+
+import threading
+from typing import Dict, List
+
+import faiss
+import numpy as np
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+DIMENSION = 128
+
+
+class UpsertPayload(BaseModel):
+    items: List[Dict[str, str]]
+
+
+class QueryPayload(BaseModel):
+    text: str
+    top_k: int = 5
+
+
+class VectorStore:
+    def __init__(self, dimension: int = DIMENSION) -> None:
+        self.dimension = dimension
+        self.index = faiss.IndexFlatIP(dimension)
+        self.lock = threading.Lock()
+        self.store: Dict[str, np.ndarray] = {}
+        self.metadata: Dict[str, Dict[str, str]] = {}
+
+    def _rebuild(self) -> None:
+        self.index.reset()
+        if not self.store:
+            return
+        matrix = np.stack(list(self.store.values())).astype("float32")
+        faiss.normalize_L2(matrix)
+        self.index.add(matrix)
+
+    def upsert(self, items: List[Dict[str, str]]) -> int:
+        changed = 0
+        with self.lock:
+            for item in items:
+                if "id" not in item or "text" not in item:
+                    raise HTTPException(status_code=400, detail="Each item requires id and text")
+                vector = self._embed(item["text"])
+                self.store[item["id"]] = vector
+                self.metadata[item["id"]] = item
+                changed += 1
+            self._rebuild()
+        return changed
+
+    def query(self, text: str, top_k: int = 5) -> List[Dict[str, str]]:
+        with self.lock:
+            if not self.store:
+                return []
+            vector = self._embed(text)
+            vector = vector.reshape(1, -1).astype("float32")
+            faiss.normalize_L2(vector)
+            distances, indices = self.index.search(vector, min(top_k, len(self.store)))
+            ids = list(self.store.keys())
+            results = []
+            for score, idx in zip(distances[0], indices[0]):
+                if idx == -1:
+                    continue
+                meta = self.metadata[ids[idx]].copy()
+                meta["score"] = float(score)
+                results.append(meta)
+            return results
+
+    def _embed(self, text: str) -> np.ndarray:
+        vector = np.zeros(self.dimension, dtype="float32")
+        for token in text.lower().split():
+            slot = hash(token) % self.dimension
+            vector[slot] += 1.0
+        if np.linalg.norm(vector) == 0.0:
+            vector[0] = 1.0
+        return vector
+
+
+store = VectorStore()
+app = FastAPI(title="Sado Vector Store", version="0.1.0")
+
+
+@app.get("/healthz")
+def healthz() -> Dict[str, str]:
+    return {"status": "ok"}
+
+
+@app.post("/upsert")
+def upsert(payload: UpsertPayload) -> Dict[str, int]:
+    return {"upserted": store.upsert(payload.items)}
+
+
+@app.post("/query")
+def query(payload: QueryPayload) -> Dict[str, List[Dict[str, str]]]:
+    return {"matches": store.query(payload.text, payload.top_k)}


### PR DESCRIPTION
## Summary
- add docker-compose stack for API, dashboard, scheduler, and optional FAISS vector service tuned for Synology Container Manager
- implement FastAPI maintenance copilot API with portfolio insights, vector integration, and sample datasets
- deliver dashboard UI, scheduler jobs, and vector microservice containers sharing a common data volume

## Testing
- python -m compileall api/src dashboard/src scheduler/src vectorstore/src
- python -m compileall scheduler/src
- docker compose config *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68ce0af7b8d08322af1182d79784df14